### PR TITLE
Fix gitignore file EOL type problem

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# gitignore contains Icon^M <- CRLF end
+# skip autocrlf,diff enable -> not binary, set -text
+.gitignore      -text


### PR DESCRIPTION
Problem:

`.gitignore` contains 

```
# Icon must end with two \r
Icon
```

This will confuse newlines(LF) and cause unnecessary diffs (It looks as if it has been changed without any change)
This problem under autocrlf Windows Environment.

Solution:
`.gitignore` as non convert text set at `.gitattribute`.


---

`.gitignore` にLFを混乱させる設定があるため、`.gitattribute` で変換対象外にするPRです。

autocrlfで変換する環境だと、差分があるようにチェックアウトされるし、この設定は個人依存なのでどうしようもありません。
リポジトリとしてはLF,CRLF混在ファイルはnon-text相当(変換しない)にするしかないかなと思いました。
