### PR TITLE
Define autocommand on demand

### DIFF
--- a/autoload/inspecthi.vim
+++ b/autoload/inspecthi.vim
@@ -102,6 +102,10 @@ endfunction
 
 
 function! inspecthi#show_inspector() abort
+  augroup inspecthi_vim
+    autocmd CursorMoved <buffer> call inspecthi#on_cursormoved()
+    autocmd BufLeave <buffer> call inspecthi#on_bufleave()
+  augroup END
   call s:init_vars()
   call s:show_popup()
   let b:inspecthi.shows_inspector = 1
@@ -112,6 +116,9 @@ function! inspecthi#hide_inspector() abort
   call s:init_vars()
   call s:close_popup()
   let b:inspecthi.shows_inspector = 0
+  augroup inspecthi_vim
+    autocmd! * <buffer>
+  augroup END
 endfunction
 
 

--- a/plugin/inspecthi.vim
+++ b/plugin/inspecthi.vim
@@ -7,12 +7,6 @@ if exists('g:loaded_inspecthi') && g:loaded_inspecthi
 endif
 
 
-augroup inspecthi_vim
-  autocmd! CursorMoved * call inspecthi#on_cursormoved()
-  autocmd! BufLeave * call inspecthi#on_bufleave()
-augroup END
-
-
 command! -nargs=0 Inspecthi call inspecthi#inspect()
 command! -nargs=0 InspecthiHideInspector call inspecthi#hide_inspector()
 command! -nargs=0 InspecthiShowInspector call inspecthi#show_inspector()


### PR DESCRIPTION
autocommand が常時動く形ではなく、

* `:InspecthiShowInspector` した時点で定義されて動く
* `:InspecthiHideInspector` すると autocommand が消される

ようにしました。